### PR TITLE
fix README of assign SimpleStatement routing key

### DIFF
--- a/manual/load_balancing/README.md
+++ b/manual/load_balancing/README.md
@@ -178,8 +178,8 @@ statement.setKeyspace("testKs");
 // Set the routing key manually: serialize each partition key component to its target CQL type
 ProtocolVersion protocolVersion = cluster.getConfiguration().getProtocolOptions().getProtocolVersionEnum();
 statement.setRoutingKey(
-        DataType.cint().serialize(1, protocolVersion),
-        DataType.cint().serialize(2016, protocolVersion));
+        TypeCodec.cint().serialize(1, protocolVersion),
+        TypeCodec.cint().serialize(2016, protocolVersion));
 
 session.execute(statement);
 ```


### PR DESCRIPTION
When following document to assign routing key to SimpleStatement found issue DateType.cint() doesn't has serialize method, instead should use TypeCodec.cint
